### PR TITLE
Fix the mirror action

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,7 +1,6 @@
 name: Mirror latest Sitelink-API data
 
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron:  '21 5 * * *'

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -10,8 +10,10 @@ jobs:
   scheduled:
     runs-on: ubuntu-latest
     steps:
-    - name: Check out this repo
+    - name: Check out the main branch of this repo
       uses: actions/checkout@v3
+      with:
+        ref: main
     - name: Set up node
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
Two small bugs in the mirror action

- It was running on whatever branch it was triggered by, even WIP feature & bugfix branches. This will probably cause a nightmare of merge conflicts later in the combination with #5.
- It triggers with every commit, which means in the combination with #5, you could have cascading mirrors & commits forever.
